### PR TITLE
add next parameter to redirectHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ module.exports = function (options) {
         redirect(ctx, loginURL);
       })();
 
-      return yield options.redirectHandler.call(this, nextHandler);
+      return yield options.redirectHandler.call(this, nextHandler, next);
     }
 
     debug('get user directly');


### PR DESCRIPTION
sometimes it is not necessary to redirect to the login page when user is null,
so add next parameter can make the process back to the flow

类似这样的系统：

1. 登录服务放在子域名A下，由应用A提供服务
2. 业务B放在子域名B下，使用userauth实现登录逻辑，并在getUser()中调用A的服务获取登录情况
3. 存在其他业务C，放在子域名C下。同样由A提供登录的支持

则以上A、B、C三个业务单元的登录状态应保持实时同步，为此B业务中的getUser()应每次都调用A获取登录情况。

假定B存在两个页面：

1. 页面1强依赖登录信息，在未登录情况下需要跳转到login页
2. 页面2不强依赖登录信息，且未登录时不要跳登录页，但需要展示用户信息

在目前的userauth逻辑下，将页面2配置在ignore中，能实现在未登录情况下，不跳转登录页。但由于没有触发getUser()，可能导致获取不到用户信息（在没有访问过页面1的情况下，页面2是无法取到登录信息的）。

因此在userauth中的redirectHandler中增加了next的传递，针对这类的需求，业务B可以不要配置ignore、match字段，从而使用所有页面均触发getUser()获取登录状态。对于不要强行跳登录页面页面，可以在redirectHandler进行判断处理，将流程转回到next中，由具体的页面controller处理。

对于没有此类需求的业务，以上不影响原有逻辑。