### PR TITLE
fix: should check user info in session, not only check session exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = function (options) {
     debug('url: %s, path: %s, loginPath: %s, session exists: %s, login required: %s',
       ctx.url, ctx.path, options.loginPath, !!ctx.session, loginRequired);
 
-    if (!ctx.session) {
+    if (!ctx.session || !ctx.session[options.userField]) {
       debug('ctx.session not exists');
       // ignore not match path
       if (!loginRequired) {


### PR DESCRIPTION
当 session 存在时但是用户信息不存在时，而当前请求是 `/login`，但是我的`ignore` 逻辑中因为其他一些条件的限制，也会导致该请求不进入登录页。